### PR TITLE
https://github.com/meveo-org/meveo/issues/666

### DIFF
--- a/meveo-admin-ejbs/src/main/java/org/meveo/service/crm/impl/CustomFieldInstanceService.java
+++ b/meveo-admin-ejbs/src/main/java/org/meveo/service/crm/impl/CustomFieldInstanceService.java
@@ -1,5 +1,7 @@
 package org.meveo.service.crm.impl;
 
+import java.io.File;
+import java.io.InputStream;
 import java.math.BigDecimal;
 import java.math.BigInteger;
 import java.time.Instant;
@@ -54,6 +56,7 @@ import org.meveo.model.crm.custom.CustomFieldStorageTypeEnum;
 import org.meveo.model.crm.custom.CustomFieldTypeEnum;
 import org.meveo.model.crm.custom.CustomFieldValue;
 import org.meveo.model.crm.custom.CustomFieldValues;
+import org.meveo.model.customEntities.BinaryProvider;
 import org.meveo.model.customEntities.CustomEntityInstance;
 import org.meveo.model.customEntities.CustomEntityTemplate;
 import org.meveo.model.persistence.DBStorageType;
@@ -714,6 +717,10 @@ public class CustomFieldInstanceService extends BaseService {
         		
         	} else {
         		cfValue = entity.getCfValuesNullSafe().setValue(cfCode, value);
+                if(cft.getFieldType() == CustomFieldTypeEnum.BINARY && (cfValue.getListBinaries() == null
+                        || cfValue.getListBinaries().isEmpty())){
+                    cfValue.setListBinaries(Arrays.asList(new BinaryProvider(new File(value.toString()))));
+                }
         	}
         	
             log.trace("Setting CF value 2. Code: {}, cfValue {}", cfCode, cfValue);


### PR DESCRIPTION
For Normal CRUD of this case initially assign list of files that are set right at the time of file upload form CRUD GUI. For normal crossstorage API to save it, we do not have this value initialized already, which eventually is the reason of not creating a file on configured binary path directory. And hence throwing exception when file not exists check failed.